### PR TITLE
Backend public key handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(COMPONENT_REQUIRES
         ubirch-esp32-storage
         )
 set(COMPONENT_PRIV_REQUIRES
+        ubirch-esp32-key-storage
         nvs_flash
         console
         )

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ If no wakeup option is specified, will sleep indefinitely.
   - `<ssid>`  SSID of AP
   - `<pass>`  PSK of AP (optional)
 
+- **update_backendkey** `[<backendkey>]` ->
+  Updates the backend public key, which is used to verify responses from the backend
+  - `[<backendkey>]` backend public key in base64 string format (optional, if none is given, the key is reset to the
+     default key given as Kconfig configuration value).
+
 - **status** -> Get the current status of the system
 
 - **exit** -> Exit the console and resume with program

--- a/cmd_ubirch.c
+++ b/cmd_ubirch.c
@@ -134,6 +134,50 @@ void register_status() {
 }
 
 /*
+ * 'update_backendkey' command to set backend verification key or load default value into flash
+ */
+
+/*
+ * Arguments used by 'update_backendkey' function
+ */
+static struct {
+    struct arg_str *backendkey;
+    struct arg_end *end;
+} update_backendkey_args;
+
+static int update_backendkey(int argc, char **argv) {
+    int nerrors = arg_parse(argc, argv, (void **) &update_backendkey_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, update_backendkey_args.end, argv[0]);
+        return 1;
+    }
+
+    if (update_backendkey_args.backendkey->count == 0 && set_backend_default_public_key() == ESP_OK) {
+        return 0;
+    } else if (update_backendkey_args.backendkey->count == 1
+            && set_backend_public_key(update_backendkey_args.backendkey->sval[0]) == ESP_OK) {
+        return 0;
+    }
+    return 1;
+}
+
+void register_update_backendkey() {
+    update_backendkey_args.backendkey = arg_str0(NULL, NULL, "<backendkey>", "Backend signing key in base64 format");
+    update_backendkey_args.backendkey->sval[0] = ""; // default value
+    update_backendkey_args.end = arg_end(2);
+
+    const esp_console_cmd_t update_backendkey_cmd = {
+            .command = "update_backendkey",
+            .help = "Update backend key or reset to default value",
+            .hint = NULL,
+            .func = &update_backendkey,
+            .argtable = &update_backendkey_args
+    };
+
+    ESP_ERROR_CHECK(esp_console_cmd_register(&update_backendkey_cmd));
+}
+
+/*
  * 'join' command to connect with wifi network
  */
 

--- a/cmd_ubirch.c
+++ b/cmd_ubirch.c
@@ -33,6 +33,7 @@
 
 #include "cmd_ubirch.h"
 #include "storage.h"
+#include "key_handling.h"
 
 /*
  * 'exit' command exits the console and runs the rest of the program
@@ -86,6 +87,14 @@ static int run_status(int argc, char **argv) {
         free(key);
     } else {
         printf("Public key not available.\r\n");
+    }
+
+    // show backend key
+    char keybuffer[PUBLICKEY_BASE64_STRING_LENGTH + 1];
+    if (get_backend_public_key(keybuffer, sizeof(keybuffer)) == ESP_OK) {
+        printf("Backend public key: %s\n", keybuffer);
+    } else {
+        printf("Backend public key not available.\r\n");
     }
 
     // show the wifi login information, if available

--- a/cmd_ubirch.c
+++ b/cmd_ubirch.c
@@ -162,13 +162,13 @@ static int update_backendkey(int argc, char **argv) {
 }
 
 void register_update_backendkey() {
-    update_backendkey_args.backendkey = arg_str0(NULL, NULL, "<backendkey>", "Backend signing key in base64 format");
+    update_backendkey_args.backendkey = arg_str0(NULL, NULL, "<backendkey>", "Backend public key in base64 format");
     update_backendkey_args.backendkey->sval[0] = ""; // default value
     update_backendkey_args.end = arg_end(2);
 
     const esp_console_cmd_t update_backendkey_cmd = {
             .command = "update_backendkey",
-            .help = "Update backend key or reset to default value",
+            .help = "Update backend key or reset to default key if <backendkey>-option is empty.",
             .hint = NULL,
             .func = &update_backendkey,
             .argtable = &update_backendkey_args

--- a/cmd_ubirch.h
+++ b/cmd_ubirch.h
@@ -40,5 +40,8 @@ void register_exit();
 // Register the status
 void register_status();
 
+// Register update_backendkey
+void register_update_backendkey();
+
 
 #endif //EXAMPLE_ESP32_CONSOLE_CMD_H

--- a/ubirch_console.c
+++ b/ubirch_console.c
@@ -129,6 +129,7 @@ void run_console(void) {
     register_system();
     register_wifi();
     register_status();
+    register_update_backendkey();
     register_exit();
 
     /* Prompt to be printed before each line.


### PR DESCRIPTION
This PR
* **adds** the backend public key to the _status_ command output
* **adds** _update_backendkey_ console command that loads the default key (given by Kconfig) if no parameter is given or accepts a key in base64 string as parameter