### PR TITLE
Add update_keys command

### DIFF
--- a/cmd_ubirch.c
+++ b/cmd_ubirch.c
@@ -242,3 +242,22 @@ void register_wifi() {
     ESP_ERROR_CHECK(esp_console_cmd_register(&join_cmd));
 }
 
+/*
+ * 'update_keys' command to create new key pair and update it in backend
+ */
+
+static int run_update_keys(int argc, char **argv) {
+    update_keys();
+    return 0;
+}
+
+void register_update_keys() {
+    const esp_console_cmd_t cmd = {
+            .command = "update_keys",
+            .help = "Update key pair and update it in backend.",
+            .hint = NULL,
+            .func = &run_update_keys,
+    };
+
+    ESP_ERROR_CHECK(esp_console_cmd_register(&cmd));
+}

--- a/cmd_ubirch.h
+++ b/cmd_ubirch.h
@@ -43,5 +43,8 @@ void register_status();
 // Register update_backendkey
 void register_update_backendkey();
 
+// Register update_keys
+void register_update_keys();
+
 
 #endif //EXAMPLE_ESP32_CONSOLE_CMD_H

--- a/ubirch_console.c
+++ b/ubirch_console.c
@@ -130,6 +130,7 @@ void run_console(void) {
     register_wifi();
     register_status();
     register_update_backendkey();
+    register_update_keys();
     register_exit();
 
     /* Prompt to be printed before each line.


### PR DESCRIPTION
This PR adds a new console command to trigger a key update (calling `update_keys` from ubirch-esp32-key-storage).